### PR TITLE
Add status reporting API to bastion (1025)

### DIFF
--- a/ansible/roles/status-report-install/defaults/main.yml
+++ b/ansible/roles/status-report-install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"

--- a/ansible/roles/status-report-install/tasks/main.yml
+++ b/ansible/roles/status-report-install/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: Create application folder
+  file:
+    name: "/opt/status/src"
+    state: directory
+    owner: "{{ ansible_user }}"
+- name: Retrieve application source files
+  git:
+    clone: yes
+    force: yes
+    dest: "/tmp/status"
+    repo: "http://github.com/jimrigsbee/api.git"
+- name: Copy application files
+  copy:
+    dest: "/opt/status/src/{{ item }}"
+    src: "/tmp/status/{{ item }}"
+    owner: "{{ ansible_user }}"
+    mode: 0644
+    remote_src: true
+  with_items:
+    - requirements.txt
+    - server.py
+    - wsgi.py
+- name: Upgrade pip
+  pip:
+    name: pip
+    state: latest
+- name: Install python virtualenv
+  pip:
+    name: virtualenv
+    state: latest
+- name: Allow nginx to access non-standard port
+  shell: |
+    semanage port -a -t http_port_t -p tcp 30904
+    semanage port -m -t http_port_t -p tcp 30904
+
+- name: Install python application as a service
+  include_role:
+    name: Stouts.wsgi
+  vars:
+    python_enabled: false
+    wsgi_group: nginx
+    wsgi_nginx_servernames: "{{ bastion_dns_name }}"
+    wsgi_nginx_port: 30904
+    wsgi_applications:
+    - name: status
+      server: gunicorn
+      module: wsgi
+      pip_requirements: requirements.txt
+- name: Fixups for python virutal env created by Stouts
+  shell: |
+    source /opt/status/env/bin/activate
+    chown -R ec2-user:ec2-user /opt/status/env
+    wget https://bootstrap.pypa.io/ez_setup.py -O - | python
+  become: no
+
+- name: Create runtime folders
+  file:
+    name: "{{item}}"
+    state: directory
+    owner: "{{ansible_user}}"
+    group: nginx
+  with_items:
+    - /opt/status/run
+    - /opt/status/log
+- name: Fix selinux context for nginx access
+  shell: |
+    semanage fcontext -a -t httpd_sys_rw_content_t "{{item}}(/.*)?"
+    restorecon -R -v "{{item}}"
+  with_items:
+    - /opt/status/run
+    - /opt/status/log
+- name: Activate application service
+  service:
+    name: status-wsgi
+    state: restarted
+    enabled: yes

--- a/ansible/roles/status-report-install/vars/RedHat.yml
+++ b/ansible/roles/status-report-install/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+wsgi_service: systemd

--- a/ansible/roles/status-report/defaults/main.yml
+++ b/ansible/roles/status-report/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+report_status: false

--- a/ansible/roles/status-report/tasks/main.yml
+++ b/ansible/roles/status-report/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name:
+  set_fact:
+    bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
+  when: bastion_dns_name is not defined
+
+- name: Report provisioning status
+  uri:
+    url: "http://{{ bastion_dns_name }}:30904/api/provision/v1/report"
+    method: POST
+    body: "{{ status_json }}"
+    status_code: 200
+    body_format: json


### PR DESCRIPTION
Resolves issue #1025. Adds API that can be polled to determining the
provisioning status.
