### PR TITLE
Add status reporting API to bastion

### DIFF
--- a/ansible/roles/status-report-install/defaults/main.yml
+++ b/ansible/roles/status-report-install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"

--- a/ansible/roles/status-report-install/tasks/main.yml
+++ b/ansible/roles/status-report-install/tasks/main.yml
@@ -1,0 +1,83 @@
+---
+- name: Create application folder
+  file:
+    name: "/opt/status/src"
+    state: directory
+    owner: "{{ ansible_user }}"
+- name: Retrieve application source files
+  git:
+    clone: yes
+    force: yes
+    dest: "/tmp/status"
+    repo: "http://github.com/RedHatTraining/provisioner-api.git"
+- name: Copy application files
+  copy:
+    dest: "/opt/status/src/{{ item }}"
+    src: "/tmp/status/{{ item }}"
+    owner: "{{ ansible_user }}"
+    mode: 0644
+    remote_src: true
+  with_items:
+    - requirements.txt
+    - server.py
+    - wsgi.py
+- name: Install pip
+  package:
+    name: python36-pip
+- name: Upgrade pip
+  pip:
+    name: pip
+    state: latest
+    executable: /usr/bin/pip3
+- name: Install python virtualenv
+  pip:
+    name: virtualenv
+    state: latest
+    executable: /usr/bin/pip3
+- name: Allow nginx to access non-standard port
+  shell: |
+    semanage port -a -t http_port_t -p tcp 30904
+    semanage port -m -t http_port_t -p tcp 30904
+- name: Stouts.wsgi virtual environment fix
+  file:
+    src: /usr/local/bin/virtualenv
+    dest: /usr/bin/virtualenv
+    owner: root
+    group: root
+    state: link
+- name: Install python application as a service
+  include_role:
+    name: Stouts.wsgi
+  vars:
+    python_enabled: false
+    wsgi_group: nginx
+    wsgi_nginx_servernames: "{{ bastion_dns_name }}"
+    wsgi_nginx_port: 30904
+    wsgi_virtualenv_python: python3
+    wsgi_applications:
+    - name: status
+      server: gunicorn
+      module: wsgi
+      pip_requirements: requirements.txt
+
+- name: Create runtime folders
+  file:
+    name: "{{item}}"
+    state: directory
+    owner: "{{ansible_user}}"
+    group: nginx
+  with_items:
+    - /opt/status/run
+    - /opt/status/log
+- name: Fix selinux context for nginx access
+  shell: |
+    semanage fcontext -a -t httpd_sys_rw_content_t "{{item}}(/.*)?"
+    restorecon -R -v "{{item}}"
+  with_items:
+    - /opt/status/run
+    - /opt/status/log
+- name: Activate application service
+  service:
+    name: status-wsgi
+    state: restarted
+    enabled: yes

--- a/ansible/roles/status-report-install/vars/RedHat.yml
+++ b/ansible/roles/status-report-install/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+wsgi_service: systemd

--- a/ansible/roles/status-report/defaults/main.yml
+++ b/ansible/roles/status-report/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+report_status: false

--- a/ansible/roles/status-report/tasks/main.yml
+++ b/ansible/roles/status-report/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name:
+  set_fact:
+    bastion_dns_name: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
+  when: bastion_dns_name is not defined
+
+- name: Report provisioning status
+  uri:
+    url: "http://{{ bastion_dns_name }}:30904/api/provision/v1/report"
+    method: POST
+    body: "{{ status_json }}"
+    status_code: 200
+    body_format: json


### PR DESCRIPTION
##### SUMMARY
Add API that can store in JSON format data to report the provisioning status. The API can also be polled to determine the status.

Add two roles: `status-report-install` and `status-report`. The first role installs the status reporting API server and the second posts updates to the API.

This will be used in two feature pull requests for ansible-skylight and ocp4-workshop.

Fixes issue #1025.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
status-report-install, status-report

##### ADDITIONAL INFORMATION
Sample interaction with the status reporting API:

```
[ec2-user@bastion ~]$ curl -X POST -H "Content-Type: application/json" --data '{"foo": "bar"}' localhost:30904/api/provision/v1/report

[ec2-user@bastion ~]$ curl localhost:30904/api/provision/v1/status
{"foo":"bar"}
```