### PR TITLE
Parameterize the waiting of AWS power state.

### DIFF
--- a/ansible/configs/ocp4-workshop/README.adoc
+++ b/ansible/configs/ocp4-workshop/README.adoc
@@ -22,7 +22,7 @@ just replace in the command used to deploy, the `main.yml` with `destroy.yml`
 
 * `ansible-playbook ansible/destroy.yaml -e @/home/myself/myenvironment-variables.yml -e@/home/myself/my_secret.yml`
 
-== Sample Environmet Variables
+== Sample Environment Variables
 
 [source,yaml]
 ----
@@ -32,6 +32,7 @@ guid: myguid
 cloud_provider: ec2
 cloud_tags: {'Purpose': 'development'}
 aws_region: us-east-2
+aws_instance_wait_for_stop: true
 cloudformation_retries: 0
 key_name: ocpkey
 software_to_deploy: none

--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -84,6 +84,8 @@ HostedZoneId: Z3IHLWJZOU9SRT
 aws_region: us-east-1
 # The key that is used to
 key_name: "default_key_name"
+# Whether to wait for AWS to return that the instance has stopped
+aws_instance_wait_for_stop: false
 
 ## Networking (AWS)
 subdomain_base_short: "{{ guid }}"

--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -64,10 +64,11 @@
       when: ACTION == 'stop'
       ec2_instance:
         state: stopped
-        wait: no
+        wait: {{ aws_instance_wait_for_stop }}
         filters:
           "tag:guid": "{{ guid }}"
           "tag:env_type": "{{ env_type }}"
+          instance-state-name: running
 
     - name: Start instances by (guid, env_type) tags
       when: ACTION == 'start'
@@ -77,7 +78,7 @@
         filters:
           "tag:guid": "{{ guid }}"
           "tag:env_type": "{{ env_type }}"
-
+          instance-state-name: stopped
     - when: ACTION == 'status'
       block:
         - name: Get EC2 facts using (guid, env_type) tag


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a 'aws_instance_wait_for_stop' variable to control the AWS
instance state return.

By default, lifecycle.yml does not wait.
Fixes #1026, #1027

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workshop`

##### ADDITIONAL INFORMATION
These changes allow the user to parameterize the instance state for performance enhancements -- if `aws_instance_wait_for_stop` is set to `false`, the life-cycle playbook does not wait for the full stop of the instances to continue its execution. 