### PR TITLE
Usage of the status-report API by ocp4-workshop

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -395,5 +395,30 @@
   gather_facts: false
   become: false
   tasks:
-  - debug:
-      msg: "Post-Software checks completed successfully"
+    - name: Retrieve cluster UUID
+      block:
+        - name: Get kubeadmin password
+          slurp:
+            path: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password
+          register: kubeadminr
+
+        - name: Get Cluster ID
+          environment:
+            KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+          command: oc get clusterversion version -o jsonpath="{.spec.clusterID}"
+          register: clusteridr
+
+        - name: Set cluster id
+          set_fact:
+            cluster_id: "{{ clusteridr.stdout | trim }}"
+
+        - name: Report provisioning status
+          include_role:
+            name: status-report
+          vars:
+            classroom_status: "Classroom ready"
+            status_json: "{{ lookup('template', 'report.j2') }}"
+            bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+      when: report_status | d(false)
+    - debug:
+        msg: "Post-Software checks completed successfully"

--- a/ansible/configs/ocp4-workshop/pre_software.yml
+++ b/ansible/configs/ocp4-workshop/pre_software.yml
@@ -45,6 +45,10 @@
   become: true
   roles:
   - { role: "bastion",              when: 'install_bastion | bool' }
+  - role: "status-report-install"
+    vars:
+      bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+    when: 'report_status | d(false)'
   - { role: "bastion-student-user", when: 'install_student_user | bool' }
   - { role: "bastion-opentlc-ipa",  when: 'install_ipa_client | bool' }
   tags:

--- a/ansible/configs/ocp4-workshop/requirements.yml
+++ b/ansible/configs/ocp4-workshop/requirements.yml
@@ -4,3 +4,7 @@
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
   version: v0.17.0
+
+# From 'Stouts.wsgi'
+- src: https://github.com/Stouts/Stouts.wsgi
+  version: 2.1.4

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -1,4 +1,19 @@
 ---
+- name: OpenShift Provisioning Pre-Tasks
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: no
+  tasks:
+    - name: Report provisioning status
+      include_role:
+        name: status-report
+      vars:
+        classroom_status: "Starting the OpenShift Installation"
+        status_json: "{{ lookup('template', 'report-before-install.j2') }}"
+        bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+      when: report_status | d(false)
+
 - name: Step 00xxxxx software
   hosts: bastions
   gather_facts: false
@@ -51,7 +66,7 @@
               aws_access_key_id = {{ hostvars.localhost.student_access_key_id }}
               aws_secret_access_key = {{ hostvars.localhost.student_secret_access_key }}
 
-        # For GA Releases 
+        # For GA Releases
         - name: Set URLs for OpenShift GA releases
           when: not ocp4_installer_use_dev_preview | d(False) | bool
           set_fact:
@@ -203,6 +218,16 @@
           command: oc whoami --show-server
           register: showserver
 
+        - name: Get Cluster ID
+          environment:
+            KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+          command: oc get clusterversion version -o jsonpath="{.spec.clusterID}"
+          register: clusteridr
+
+        - name: Set cluster id
+          set_fact:
+            cluster_id: "{{ clusteridr.stdout | trim }}"
+
         - name: Print Overview
           debug:
             msg: "{{ item }}"
@@ -232,6 +257,15 @@
             - "user.info: "
             - "user.info: You *CANNOT* SSH into this environment"
           when: not install_student_user | bool
+
+        - name: Report provisioning status
+          include_role:
+            name: status-report
+          vars:
+            classroom_status: "OpenShift Installation Completed"
+            status_json: "{{ lookup('template', 'report.j2') }}"
+            bastion_dns_name: "bastion{{ guid }}{{ subdomain_base_suffix }}"
+          when: report_status | d(false)
 
       always:
         - name: Delete deployinprogress lock file

--- a/ansible/configs/ocp4-workshop/templates/report-before-install.j2
+++ b/ansible/configs/ocp4-workshop/templates/report-before-install.j2
@@ -1,0 +1,1 @@
+{ "classroom_identifier": "{{ guid }}", "classroom_type": "{{ env_type }}", "classroom_region": "{{ aws_region }}", "status": "{{ classroom_status | d('unknown') }}" }

--- a/ansible/configs/ocp4-workshop/templates/report.j2
+++ b/ansible/configs/ocp4-workshop/templates/report.j2
@@ -1,0 +1,1 @@
+{ "cluster_id": "{{ cluster_id }}", "cluster_username": "kubeadmin", "cluster_password": "{{ kubeadminr.content | b64decode }}", "cluster_api_url": "api.{{cluster_name}}{{subdomain_base_suffix}}:6443", "classroom_identifier": "{{ guid }}", "classroom_type": "{{ env_type }}", "classroom_region": "{{ aws_region }}", "status": "{{ classroom_status | d('unknown') }}" }


### PR DESCRIPTION

##### SUMMARY
Configure the ocp4-workshop config to deploy the status-report API and consume it.
Introduce a new Boolean, `report_status` that allow the enabling or disabling of that feature.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workshop`

##### ADDITIONAL INFORMATION
This pull request enable the installation and usage of the status report API by the `ocp4-workshop` config.
The `report_status` Boolean, that can be overwritten via an environment variable allow the user to enable or disable that feature on demand.

The pull request #8 takes precedence over that pull request, since it depends on the `status-report-install` role to work.